### PR TITLE
Add Zalando as clothing store

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Increasingly, Amazon isn't the best place to buy things online. Spam listings, f
 
 * [LL Bean](https://llbean.com/)
 * [Uniqlo](http://uniqlo.com)
+* [Zalando](https://zalando.com) (EU)
 
 ## Coffee and Coffee Brewing Accessories
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Increasingly, Amazon isn't the best place to buy things online. Spam listings, f
 
 * [LL Bean](https://llbean.com/)
 * [Uniqlo](http://uniqlo.com)
-* [Zalando](https://zalando.com) (EU)
+* [Zalando](https://zalando.com) - EU only
 
 ## Coffee and Coffee Brewing Accessories
 


### PR DESCRIPTION
Added Zalando as a clothing store. Although it's not available in USA, it's
available in many European countries.

> The company operates in the following countries: Germany, Austria,
> Switzerland, France, Belgium, the Netherlands, Italy, Spain, Poland, Sweden,
> Denmark, Finland, Norway, Ireland, Luxembourg, the Czech Republic and the
> United Kingdom.